### PR TITLE
Refactor type hints to use built-in generics #7

### DIFF
--- a/src/tiny8/cpu.py
+++ b/src/tiny8/cpu.py
@@ -6,7 +6,7 @@ The implementation favors readability over cycle-accurate emulation. Add
 instruction handlers by defining methods named ``op_<mnemonic>`` on ``CPU``.
 """
 
-from typing import Dict, List, Optional, Tuple
+from typing import Optional
 
 from .memory import Memory
 
@@ -29,18 +29,18 @@ class CPU:
     currently-loaded program.
 
     Attributes:
-        regs (List[int]): 32 8-bit general purpose registers (R0..R31).
+        regs (list[int]): 32 8-bit general purpose registers (R0..R31).
         pc (int): Program counter (index into ``program``).
         sp (int): Stack pointer (index into RAM in the associated
             :class:`tiny8.memory.Memory`).
         sreg (int): Status register bits stored in a single integer (I, T,
             H, S, V, N, Z, C).
         cycle (int): Instruction execution counter.
-        reg_trace (List[Tuple[int, int, int]]): Per-cycle register change
+        reg_trace (list[tuple[int, int, int]]): Per-cycle register change
             trace entries of the form ``(cycle, reg, new_value)``.
-        mem_trace (List[Tuple[int, int, int]]): Per-cycle memory change
+        mem_trace (list[tuple[int, int, int]]): Per-cycle memory change
             trace entries of the form ``(cycle, addr, new_value)``.
-        step_trace (List[dict]): Full per-step snapshots useful for
+        step_trace (list[dict]): Full per-step snapshots useful for
             visualization and debugging.
 
     Note:
@@ -52,7 +52,7 @@ class CPU:
     def __init__(self, memory: Optional[Memory] = None):
         self.mem = memory or Memory()
         # 32 general purpose 8-bit registers R0-R31
-        self.regs: List[int] = [0] * 32
+        self.regs: [int] = [0] * 32
         # Program Counter (word-addressable for AVR) - we use byte addressing for simplicity
         self.pc: int = 0
         # Stack Pointer - point into RAM
@@ -62,16 +62,16 @@ class CPU:
         # Cycle counter
         self.cycle: int = 0
         # Simple interrupt vector table (addr->enabled)
-        self.interrupts: Dict[int, bool] = {}
+        self.interrupts: dict[int, bool] = {}
         # Execution trace of register/memory changes per cycle
-        self.reg_trace: List[Tuple[int, int, int]] = []  # (cycle, reg, newval)
-        self.mem_trace: List[Tuple[int, int, int]] = []  # (cycle, addr, newval)
+        self.reg_trace: list[tuple[int, int, int]] = []  # (cycle, reg, newval)
+        self.mem_trace: list[tuple[int, int, int]] = []  # (cycle, addr, newval)
         # Full step trace: list of dicts with cycle, pc, instr_text, regs snapshot, optional mem snapshot
-        self.step_trace: List[dict] = []
+        self.step_trace: list[dict] = []
         # Program area - list of instructions as tuples: (mnemonic, *operands)
-        self.program: List[Tuple[str, Tuple]] = []
+        self.program: list[tuple[str, tuple]] = []
         # Labels -> pc
-        self.labels: Dict[str, int] = {}
+        self.labels: dict[str, int] = {}
         # Running state
         self.running = False
 
@@ -289,11 +289,11 @@ class CPU:
         self.mem_trace.append((self.cycle, addr, val & 0xFF))
 
     # Program loading
-    def load_program(self, program: List[Tuple[str, Tuple]], labels: Dict[str, int]):
+    def load_program(self, program: list[tuple[str, tuple]], labels: dict[str, int]):
         """Load an assembled program into the CPU.
 
         Args:
-            program: List of ``(mnemonic, operands)`` tuples returned by the
+            program: list of ``(mnemonic, operands)`` tuples returned by the
                 assembler.
             labels: Mapping of label strings to instruction indices.
 

--- a/src/tiny8/memory.py
+++ b/src/tiny8/memory.py
@@ -1,7 +1,5 @@
 """Memory model for tiny8 - simple RAM and ROM with change tracking."""
 
-from typing import List, Tuple
-
 
 class Memory:
     """
@@ -42,8 +40,8 @@ class Memory:
         self.ram = [0] * ram_size
         self.rom = [0] * rom_size
         # change logs: list of (addr, old, new, cycle)
-        self.ram_changes: List[Tuple[int, int, int, int]] = []
-        self.rom_changes: List[Tuple[int, int, int, int]] = []
+        self.ram_changes: list[tuple[int, int, int, int]] = []
+        self.rom_changes: list[tuple[int, int, int, int]] = []
 
     def read_ram(self, addr: int) -> int:
         """Read and return the value stored in RAM at the specified address.
@@ -87,7 +85,7 @@ class Memory:
         if old != self.ram[addr]:
             self.ram_changes.append((addr, old, self.ram[addr], cycle))
 
-    def load_rom(self, data: List[int]) -> None:
+    def load_rom(self, data: list[int]) -> None:
         """Load a ROM image into the emulator's ROM buffer.
 
         Args:
@@ -128,7 +126,7 @@ class Memory:
             raise IndexError("ROM address out of range")
         return self.rom[addr]
 
-    def snapshot_ram(self) -> List[int]:
+    def snapshot_ram(self) -> list[int]:
         """Return a snapshot copy of the emulator's RAM.
 
         Returns:
@@ -139,7 +137,7 @@ class Memory:
         """
         return list(self.ram)
 
-    def snapshot_rom(self) -> List[int]:
+    def snapshot_rom(self) -> list[int]:
         """Return a snapshot copy of the ROM contents.
 
         Returns:


### PR DESCRIPTION
Replaced typing.List, typing.Tuple, and typing.Dict with built-in list, tuple, and dict generics in cpu.py and memory.py.