### PR TITLE
Fix branch instruction in bubblesort example

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ inner_loop:
     ld r24, r22      ; r24 = B
     ; compare A and B (we'll swap if A < B)
     cp r21, r24      ; sets carry if r21 < r24
-    brcs no_swap
+    brcc no_swap
     ; swap A and B: store B into A's address, A into B's address
     st r20, r24
     st r22, r21

--- a/docs/examples/bubblesort.rst
+++ b/docs/examples/bubblesort.rst
@@ -57,7 +57,7 @@ This example demonstrates a simple bubble sort algorithm implemented in assembly
         ld r24, r22      ; r24 = B
         ; compare A and B (we'll swap if A < B)
         cp r21, r24      ; sets carry if r21 < r24
-        brcs no_swap
+        brcc no_swap
         ; swap A and B: store B into A's address, A into B's address
         st r20, r24
         st r22, r21

--- a/examples/bubblesort.asm
+++ b/examples/bubblesort.asm
@@ -46,7 +46,7 @@ inner_loop:
     ld r24, r22      ; r24 = B
     ; compare A and B (we'll swap if A < B)
     cp r21, r24      ; sets carry if r21 < r24
-    brcs no_swap
+    brcc no_swap
     ; swap A and B: store B into A's address, A into B's address
     st r20, r24
     st r22, r21


### PR DESCRIPTION
Replaces 'brcs' with 'brcc' in the bubblesort assembly example and related documentation.