### PR TITLE
Add napoleon extension to Sphinx config (#15)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.todo",
     "sphinx.ext.mathjax",
+    "sphinx.ext.napoleon",
 ]
 
 templates_path = ["_templates"]


### PR DESCRIPTION
Enabled the `sphinx.ext.napoleon` extension in `docs/conf.py` to support Google-style docstrings.