### PR TITLE
fix: terminal highlight (#30)

### DIFF
--- a/src/tiny8/cpu.py
+++ b/src/tiny8/cpu.py
@@ -353,6 +353,7 @@ class CPU:
             self.running = False
             return False
 
+        pre_exec_pc = self.pc
         instr, operands = self.program[self.pc]
 
         # Build textual form of the instruction for tracing (uppercase mnemonic
@@ -396,11 +397,12 @@ class CPU:
 
         # record step trace after execution (post-state)
         self.step_count += 1
-        source_line = self.pc_to_line.get(self.pc, -1)
+
+        source_line = self.pc_to_line.get(pre_exec_pc, -1)
         self.step_trace.append(
             {
                 "step": self.step_count,
-                "pc": self.pc,
+                "pc": pre_exec_pc,
                 "instr": instr_text,
                 "regs": regs_snapshot,
                 "mem": mem_snapshot,


### PR DESCRIPTION
This pull request makes a targeted fix to the CPU step tracing logic in `src/tiny8/cpu.py`. The change ensures that the recorded step trace accurately reflects the program counter (PC) and source line before instruction execution, improving the reliability of trace data for debugging and analysis.

Improvements to step trace accuracy:

* The step trace now records the pre-execution program counter (`pre_exec_pc`) and corresponding source line, rather than the post-execution PC, ensuring that trace entries align with the instruction about to be executed. 